### PR TITLE
Cleanup and make navigation reactive

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,5 @@
 {
 	"extends": [
 		"@nextcloud"
-	],
-	"rules": {
-		"nextcloud/no-deprecations": "warn",
-		"nextcloud/no-removed-apis": "error"
-	}
+	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
       "dependencies": {
         "@melmacaluso/vue-modal": "^2.1.0",
         "@nextcloud/axios": "^2.4.0",
+        "@nextcloud/dialogs": "^5.0.0-beta.4",
+        "@nextcloud/router": "^2.1.2",
         "@nextcloud/vue": "8.0.0-beta.5",
-        "sass": "^1.68.0",
         "vue": "^2.7.14",
+        "vue-dropdowns": "^1.1.1",
         "vue-material-design-icons": "^5.2.0",
         "vue-router": "^3.5.1"
       },
@@ -21,12 +23,13 @@
         "@nextcloud/browserslist-config": "3.0.0",
         "@nextcloud/eslint-config": "^8.3.0",
         "@nextcloud/eslint-plugin": "^2.1.0",
-        "@nextcloud/vite-config": "^1.0.0-beta.19",
-        "vite": "^4.4.9",
-        "vue-dropdowns": "^1.1.1"
+        "@nextcloud/vite-config": "^1.0.0",
+        "sass": "^1.68.0",
+        "vite": "^4.4.9"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3080,17 +3083,17 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.37.0.tgz",
-      "integrity": "sha512-df/wffWpDhYRw7kzdxeHGsCpim+dC8aFiZlsJb4uFvVPWhBZpDzOhQxSUTFx3Df1ORY+/JjuPR3fDE9Hq+PHzQ==",
+      "version": "7.38.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.38.0.tgz",
+      "integrity": "sha512-e1LhZYnfw+JEebuY2bzhw0imDCl1nwjSThTrQqBXl40hrVo6xm3j/1EpUr89QyzgjqmAwek2ZkIVZbrhaR+cqg==",
       "dev": true,
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.28.0",
+        "@microsoft/api-extractor-model": "7.28.2",
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.60.0",
-        "@rushstack/rig-package": "0.5.0",
-        "@rushstack/ts-command-line": "4.16.0",
+        "@rushstack/node-core-library": "3.61.0",
+        "@rushstack/rig-package": "0.5.1",
+        "@rushstack/ts-command-line": "4.16.1",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
         "resolve": "~1.22.1",
@@ -3103,14 +3106,14 @@
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.28.0.tgz",
-      "integrity": "sha512-QIMtUVm1tqiKG+M6ciFgRShcDoovyltaeg+CbyOnyr7SMrp6gg0ojK5/nToMqR9kAvsTS4QVgW4Twl50EoAjcw==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.28.2.tgz",
+      "integrity": "sha512-vkojrM2fo3q4n4oPh4uUZdjJ2DxQ2+RnDQL/xhTWSRUNPF6P4QyrvY357HBxbnltKcYu+nNNolVqc6TIGQ73Ig==",
       "dev": true,
       "dependencies": {
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.60.0"
+        "@rushstack/node-core-library": "3.61.0"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
@@ -3344,22 +3347,20 @@
       }
     },
     "node_modules/@nextcloud/dialogs": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-4.2.1.tgz",
-      "integrity": "sha512-rimwdQ2AsE1X4cr5Z7EkWbtTSQyb/jXNNA4ZEZtcS3uBdRjwr0dbnvml7OhXCwrBjeYmn7+xT49MwoREO4DBAQ==",
+      "version": "5.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-5.0.0-beta.4.tgz",
+      "integrity": "sha512-P2F2Aa76/sfwI2tXItvvBINDgdXuURWuhMpRugywt3NV5ZK4hLfvXVCnR2JnTzrMg1+jK1kPyOrAsdsRFj2vkg==",
       "dependencies": {
-        "@mdi/svg": "^7.2.96",
-        "@nextcloud/files": "^3.0.0-beta.14",
+        "@nextcloud/files": "^3.0.0-beta.21",
         "@nextcloud/l10n": "^2.2.0",
         "@nextcloud/router": "^2.1.2",
         "@nextcloud/typings": "^1.7.0",
-        "@nextcloud/vue": "^7.12.4",
-        "@types/toastify-js": "^1.12.1",
+        "@nextcloud/vue": "^8.0.0-beta.5",
+        "@types/toastify-js": "^1.12.0",
         "@vueuse/core": "^10.4.1",
         "toastify-js": "^1.12.0",
         "vue-frag": "^1.4.3",
-        "vue-material-design-icons": "^5.2.0",
-        "webdav": "^5.2.3"
+        "webdav": "^5.3.0"
       },
       "engines": {
         "node": "^20.0.0",
@@ -3367,166 +3368,6 @@
       },
       "peerDependencies": {
         "vue": "^2.7.14"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/vue": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.12.5.tgz",
-      "integrity": "sha512-gXqJrWFvXpF4w/JGZfNH9fDXOOCSK5i+/G6pwcrpG2YFbQ4wgvrqGKmiNwTHcAqTI26lCFrnVDZ6f5CwBorknA==",
-      "dependencies": {
-        "@floating-ui/dom": "^1.1.0",
-        "@nextcloud/auth": "^2.0.0",
-        "@nextcloud/axios": "^2.0.0",
-        "@nextcloud/browser-storage": "^0.2.0",
-        "@nextcloud/calendar-js": "^6.0.0",
-        "@nextcloud/capabilities": "^1.0.4",
-        "@nextcloud/dialogs": "^4.0.0",
-        "@nextcloud/event-bus": "^3.0.0",
-        "@nextcloud/initial-state": "^2.0.0",
-        "@nextcloud/l10n": "^2.0.1",
-        "@nextcloud/logger": "^2.2.1",
-        "@nextcloud/router": "^2.0.0",
-        "@nextcloud/vue-select": "^3.21.2",
-        "@skjnldsv/sanitize-svg": "^1.0.2",
-        "@vueuse/components": "^10.0.2",
-        "clone": "^2.1.2",
-        "debounce": "1.2.1",
-        "emoji-mart-vue-fast": "^12.0.1",
-        "escape-html": "^1.0.3",
-        "floating-vue": "^1.0.0-beta.19",
-        "focus-trap": "^7.4.3",
-        "hammerjs": "^2.0.8",
-        "linkify-string": "^4.0.0",
-        "md5": "^2.3.0",
-        "node-polyfill-webpack-plugin": "^2.0.1",
-        "rehype-external-links": "^3.0.0",
-        "rehype-react": "^7.1.2",
-        "remark-breaks": "^3.0.2",
-        "remark-parse": "^10.0.1",
-        "remark-rehype": "^10.1.0",
-        "splitpanes": "^2.4.1",
-        "string-length": "^5.0.1",
-        "striptags": "^3.2.0",
-        "tributejs": "^5.1.3",
-        "unified": "^10.1.2",
-        "unist-builder": "^3.0.1",
-        "unist-util-visit": "^4.1.2",
-        "vue": "^2.7.14",
-        "vue-color": "^2.8.1",
-        "vue-frag": "^1.4.3",
-        "vue-material-design-icons": "^5.1.2",
-        "vue-multiselect": "^2.1.6",
-        "vue2-datepicker": "^3.11.0"
-      },
-      "engines": {
-        "node": "^16.0.0",
-        "npm": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/emoji-mart-vue-fast": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-12.0.5.tgz",
-      "integrity": "sha512-XFNwIk+ConSAjC4tmk//s6btlo3oQco7TBgP914Qytg/15jLa/0VrWNg271W2MTv+8N8BxYl2dDn3cZJxcreqw==",
-      "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "core-js": "^3.23.5"
-      },
-      "peerDependencies": {
-        "vue": ">2.0.0"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/unified": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "bail": "^2.0.0",
-        "extend": "^3.0.0",
-        "is-buffer": "^2.0.0",
-        "is-plain-obj": "^4.0.0",
-        "trough": "^2.0.0",
-        "vfile": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/unist-builder": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-3.0.1.tgz",
-      "integrity": "sha512-gnpOw7DIpCA0vpr6NqdPvTWnlPTApCTRzr+38E6hCWx3rz/cjo83SsKIlS1Z+L5ttScQ2AwutNnb8+tAvpb6qQ==",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/unist-util-visit": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
-      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0",
-        "unist-util-visit-parents": "^5.1.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/vfile": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "unist-util-stringify-position": "^3.0.0",
-        "vfile-message": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/vfile-message": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
-      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@nextcloud/eslint-config": {
@@ -3697,22 +3538,22 @@
       }
     },
     "node_modules/@nextcloud/vite-config": {
-      "version": "1.0.0-beta.19",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-1.0.0-beta.19.tgz",
-      "integrity": "sha512-LiIJjGy05hcNYoSAOxjpR8ttyfmVkZYPeVcnM2OLUcJ+W3f+6T+voM9rb8pH7D7ojQ2egIy2Xm+LPxcMJQDKHw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-1.0.0.tgz",
+      "integrity": "sha512-C9UUNsdYKZc45S7nRk1SpMOvEdGDiOJBdCuuZIBgf3eE9y7Wxi4xWBPCtJQ+Me1pIZksmMfTIbfHR3+P7qrv0w==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-replace": "^5.0.2",
         "@vitejs/plugin-vue2": "^2.2.0",
         "browserslist-to-esbuild": "^1.2.0",
-        "magic-string": "^0.30.2",
+        "magic-string": "^0.30.4",
         "rollup-plugin-corejs": "^1.0.0-beta.0",
         "rollup-plugin-esbuild-minify": "^1.1.0",
-        "rollup-plugin-license": "^3.0.1",
+        "rollup-plugin-license": "^3.1.0",
         "rollup-plugin-node-externals": "^6.1.1",
-        "vite-plugin-css-injected-by-js": "^3.2.1",
-        "vite-plugin-dts": "^3.3.1",
-        "vite-plugin-node-polyfills": "^0.9.0"
+        "vite-plugin-css-injected-by-js": "^3.3.0",
+        "vite-plugin-dts": "^3.6.0",
+        "vite-plugin-node-polyfills": "^0.15.0"
       },
       "engines": {
         "node": "^20",
@@ -3782,6 +3623,192 @@
       "integrity": "sha512-TerpWxDtbdwda32xtrLcqN8CjcQwVwCrEdHIHIAPQ2y3Ktl/dcjQxGn0onRZqk9+4ZxPGMYdX7LIWRKCHUlrmQ==",
       "peerDependencies": {
         "vue": "2.x"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@nextcloud/dialogs": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-4.2.1.tgz",
+      "integrity": "sha512-rimwdQ2AsE1X4cr5Z7EkWbtTSQyb/jXNNA4ZEZtcS3uBdRjwr0dbnvml7OhXCwrBjeYmn7+xT49MwoREO4DBAQ==",
+      "dependencies": {
+        "@mdi/svg": "^7.2.96",
+        "@nextcloud/files": "^3.0.0-beta.14",
+        "@nextcloud/l10n": "^2.2.0",
+        "@nextcloud/router": "^2.1.2",
+        "@nextcloud/typings": "^1.7.0",
+        "@nextcloud/vue": "^7.12.4",
+        "@types/toastify-js": "^1.12.1",
+        "@vueuse/core": "^10.4.1",
+        "toastify-js": "^1.12.0",
+        "vue-frag": "^1.4.3",
+        "vue-material-design-icons": "^5.2.0",
+        "webdav": "^5.2.3"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^9.0.0"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.14"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@nextcloud/vue": {
+      "version": "7.12.6",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.12.6.tgz",
+      "integrity": "sha512-8Blh7IeKUymLOehD7hgoidh8rk65ovIJrodzEWYv3VN9YtXrikWRLxulNSatAyupIHa4/4pt3RSHkHsct/Nfmw==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.1.0",
+        "@nextcloud/auth": "^2.0.0",
+        "@nextcloud/axios": "^2.0.0",
+        "@nextcloud/browser-storage": "^0.2.0",
+        "@nextcloud/calendar-js": "^6.0.0",
+        "@nextcloud/capabilities": "^1.0.4",
+        "@nextcloud/dialogs": "^4.0.0",
+        "@nextcloud/event-bus": "^3.0.0",
+        "@nextcloud/initial-state": "^2.0.0",
+        "@nextcloud/l10n": "^2.0.1",
+        "@nextcloud/logger": "^2.2.1",
+        "@nextcloud/router": "^2.0.0",
+        "@nextcloud/vue-select": "^3.21.2",
+        "@skjnldsv/sanitize-svg": "^1.0.2",
+        "@vueuse/components": "^10.0.2",
+        "clone": "^2.1.2",
+        "debounce": "1.2.1",
+        "emoji-mart-vue-fast": "^12.0.1",
+        "escape-html": "^1.0.3",
+        "floating-vue": "^1.0.0-beta.19",
+        "focus-trap": "^7.4.3",
+        "hammerjs": "^2.0.8",
+        "linkify-string": "^4.0.0",
+        "md5": "^2.3.0",
+        "node-polyfill-webpack-plugin": "^2.0.1",
+        "rehype-external-links": "^3.0.0",
+        "rehype-react": "^7.1.2",
+        "remark-breaks": "^3.0.2",
+        "remark-parse": "^10.0.1",
+        "remark-rehype": "^10.1.0",
+        "splitpanes": "^2.4.1",
+        "string-length": "^5.0.1",
+        "striptags": "^3.2.0",
+        "tributejs": "^5.1.3",
+        "unified": "^10.1.2",
+        "unist-builder": "^3.0.1",
+        "unist-util-visit": "^4.1.2",
+        "vue": "^2.7.14",
+        "vue-color": "^2.8.1",
+        "vue-frag": "^1.4.3",
+        "vue-material-design-icons": "^5.1.2",
+        "vue-multiselect": "^2.1.6",
+        "vue2-datepicker": "^3.11.0"
+      },
+      "engines": {
+        "node": "^16.0.0",
+        "npm": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@nextcloud/vue/node_modules/emoji-mart-vue-fast": {
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-12.0.5.tgz",
+      "integrity": "sha512-XFNwIk+ConSAjC4tmk//s6btlo3oQco7TBgP914Qytg/15jLa/0VrWNg271W2MTv+8N8BxYl2dDn3cZJxcreqw==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "core-js": "^3.23.5"
+      },
+      "peerDependencies": {
+        "vue": ">2.0.0"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@nextcloud/vue/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@nextcloud/vue/node_modules/unist-builder": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-3.0.1.tgz",
+      "integrity": "sha512-gnpOw7DIpCA0vpr6NqdPvTWnlPTApCTRzr+38E6hCWx3rz/cjo83SsKIlS1Z+L5ttScQ2AwutNnb8+tAvpb6qQ==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@nextcloud/vue/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
@@ -3928,9 +3955,9 @@
       }
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "3.60.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.60.0.tgz",
-      "integrity": "sha512-PcyrqhILvzU+65wMFybQ2VeGNnU5JzhDq2OvUi3j6jPUxyllM7b2hrRUwCuVaYboewYzIbpzXFzgxe2K7ii1nw==",
+      "version": "3.61.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.61.0.tgz",
+      "integrity": "sha512-tdOjdErme+/YOu4gPed3sFS72GhtWCgNV9oDsHDnoLY5oDfwjKUc9Z+JOZZ37uAxcm/OCahDHfuu2ugqrfWAVQ==",
       "dev": true,
       "dependencies": {
         "colors": "~1.2.1",
@@ -3984,9 +4011,9 @@
       "dev": true
     },
     "node_modules/@rushstack/rig-package": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.0.tgz",
-      "integrity": "sha512-bGnOW4DWHOePDiABKy6qyqYJl9i7fKn4bRucExRVt5QzyPxuVHMl8CMmCabtoNSpXzgG3qymWOrMoa/W2PpJrw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.1.tgz",
+      "integrity": "sha512-pXRYSe29TjRw7rqxD4WS3HN/sRSbfr+tJs4a9uuaSIBAITbUggygdhuG0VrO0EO+QqH91GhYMN4S6KRtOEmGVA==",
       "dev": true,
       "dependencies": {
         "resolve": "~1.22.1",
@@ -3994,9 +4021,9 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.16.0.tgz",
-      "integrity": "sha512-WJKhdR9ThK9Iy7t78O3at7I3X4Ssp5RRZay/IQa8NywqkFy/DQbT3iLouodMMdUwLZD9n8n++xLubVd3dkmpkg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.16.1.tgz",
+      "integrity": "sha512-+OCsD553GYVLEmz12yiFjMOzuPeCiZ3f8wTiFHL30ZVXexTyPmgjwXEhg2K2P0a2lVf+8YBy7WtPoflB2Fp8/A==",
       "dev": true,
       "dependencies": {
         "@types/argparse": "1.0.38",
@@ -4702,9 +4729,9 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.14.tgz",
-      "integrity": "sha512-15GGOkUP/AgE/jzGdUMtOaQ+XPokrP+Q5Z0DS3aun3i72E6MjFvwB7E2k/ap0mABjdRCRjoVPnsMF1+TkzGqQg==",
+      "version": "1.8.15",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.15.tgz",
+      "integrity": "sha512-zche5Aw8kkvp3YaghuLiOZyVIpoWHjSQ0EfjxGSsqHOPMamdCoa9x3HtbenpR38UMUoKJ88wiWuiOrV3B/Yq+A==",
       "dev": true,
       "dependencies": {
         "@volar/language-core": "~1.10.0",
@@ -4765,13 +4792,13 @@
       "dev": true
     },
     "node_modules/@vue/typescript": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@vue/typescript/-/typescript-1.8.14.tgz",
-      "integrity": "sha512-ZNV6MkYNCNNyYSty/uvlChxftOUhpeTr3TkoMkwhovjXQERM3IBCP2lcOLnT6gb7dQ9vdN7dI5kPf8PYPmbkUA==",
+      "version": "1.8.15",
+      "resolved": "https://registry.npmjs.org/@vue/typescript/-/typescript-1.8.15.tgz",
+      "integrity": "sha512-qWyanQKXOsK84S8rP7QBrqsvUdQ0nZABZmTjXMpb3ox4Bp5IbkscREA3OPUrkgl64mAxwwCzIWcOc3BPTCPjQw==",
       "dev": true,
       "dependencies": {
         "@volar/typescript": "~1.10.0",
-        "@vue/language-core": "1.8.14"
+        "@vue/language-core": "1.8.15"
       }
     },
     "node_modules/@vueuse/components": {
@@ -5808,6 +5835,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -6017,6 +6045,31 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "node_modules/buffer-polyfill": {
+      "name": "buffer",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -6180,6 +6233,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -8373,6 +8427,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "devOptional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -8727,7 +8782,8 @@
     "node_modules/immutable": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
-      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA=="
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
+      "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -8896,6 +8952,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "devOptional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -8983,6 +9040,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9021,6 +9079,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "devOptional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -11122,9 +11181,9 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
     },
     "node_modules/magic-string": {
-      "version": "0.30.3",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
-      "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
+      "version": "0.30.4",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.4.tgz",
+      "integrity": "sha512-Q/TKtsC5BPm0kGqgBIF9oXAs/xEf2vRKiIB4wCRQTJOQIByZ1d+NnUOotvJOvNpi5RNIgVOMC3pOuaP1ZTDlVg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -12801,6 +12860,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "devOptional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -13643,6 +13703,7 @@
       "version": "1.68.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.68.0.tgz",
       "integrity": "sha512-Lmj9lM/fef0nQswm1J2HJcEsBUba4wgNx2fea6yJHODREoMFnwRpZydBnX/RjyXw2REIwdkbqE4hrTo4qfDBUA==",
+      "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -15003,9 +15064,9 @@
       }
     },
     "node_modules/vite-plugin-dts": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-3.5.4.tgz",
-      "integrity": "sha512-BJLBj1Vg9kV7ZMXAULT9UGogrElwz5s+k8TzC7LsFkHv5Jy90OWnHKUp8qm7sypu2pkF5pTJ5McUuHudnT0Imw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-3.6.0.tgz",
+      "integrity": "sha512-doxhDRFJCZD2sGjIp4V800nm8Y19GvmwckjG5vYPuiqJ7OBjc9NlW1Vp9Gkyh2aXlUs1jTDRH/lxWfcsPLOQHg==",
       "dev": true,
       "dependencies": {
         "@microsoft/api-extractor": "^7.36.4",
@@ -15029,13 +15090,15 @@
       }
     },
     "node_modules/vite-plugin-node-polyfills": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.9.0.tgz",
-      "integrity": "sha512-+i+WPUuIBhJy+ODfxx6S6FTl28URCxUszbl/IL4GwrZvbqqY/8VDIp+zpjMS8Us/a7GwN4Iaqr/fVIBtkNQojQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.15.0.tgz",
+      "integrity": "sha512-IF9aTSPV9zebrcC6ezJA3Ym4r4U1C3jKUAnG16Sq7+UPtisNEOcNOAu3p5wcgFFOuuUwAUjQlIeJHMcnSXXemQ==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-inject": "^5.0.3",
-        "node-stdlib-browser": "^1.2.0"
+        "buffer-polyfill": "npm:buffer@^6.0.3",
+        "node-stdlib-browser": "^1.2.0",
+        "process": "^0.11.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/davidmyersdev"
@@ -15471,8 +15534,7 @@
     "node_modules/vue-dropdowns": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vue-dropdowns/-/vue-dropdowns-1.1.2.tgz",
-      "integrity": "sha512-1zISzpdf+GaQfI8yyCSASGJkb3vkjr2ZtX276wSdix2F1pXU9stkvDPFUM5ac9sAWY/3rZjBSvw9bTBvFTGnTw==",
-      "dev": true
+      "integrity": "sha512-1zISzpdf+GaQfI8yyCSASGJkb3vkjr2ZtX276wSdix2F1pXU9stkvDPFUM5ac9sAWY/3rZjBSvw9bTBvFTGnTw=="
     },
     "node_modules/vue-eslint-parser": {
       "version": "9.3.1",
@@ -15627,13 +15689,13 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.14.tgz",
-      "integrity": "sha512-nlxsS8pbTCVho2Yqc4fvygDrXsdzftYdBHH2EO5m9KHjJYwYo8LtGGJ3XVl9ayqZlt+WfuzUD6Hts7va7+wdUQ==",
+      "version": "1.8.15",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.15.tgz",
+      "integrity": "sha512-4DoB3LUj7IToLmggoCxRiFG+QU5lem0nv03m1ocqugXA9rSVoTOEoYYaP8vu8b99Eh+/cCVdYOeIAQ+RsgUYUw==",
       "dev": true,
       "dependencies": {
-        "@vue/language-core": "1.8.14",
-        "@vue/typescript": "1.8.14",
+        "@vue/language-core": "1.8.15",
+        "@vue/typescript": "1.8.15",
         "semver": "^7.3.8"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -27,24 +27,27 @@
   "dependencies": {
     "@melmacaluso/vue-modal": "^2.1.0",
     "@nextcloud/axios": "^2.4.0",
+    "@nextcloud/dialogs": "^5.0.0-beta.4",
+    "@nextcloud/router": "^2.1.2",
     "@nextcloud/vue": "8.0.0-beta.5",
-    "sass": "^1.68.0",
     "vue": "^2.7.14",
+    "vue-dropdowns": "^1.1.1",
     "vue-material-design-icons": "^5.2.0",
     "vue-router": "^3.5.1"
-  },
-  "browserslist": [
-    "extends @nextcloud/browserslist-config"
-  ],
-  "engines": {
-    "node": ">=18.0.0"
   },
   "devDependencies": {
     "@nextcloud/browserslist-config": "3.0.0",
     "@nextcloud/eslint-config": "^8.3.0",
     "@nextcloud/eslint-plugin": "^2.1.0",
-    "@nextcloud/vite-config": "^1.0.0-beta.19",
-    "vue-dropdowns": "^1.1.1",
+    "@nextcloud/vite-config": "^1.0.0",
+    "sass": "^1.68.0",
     "vite": "^4.4.9"
-  }
+  },
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=9.0.0"
+  },
+  "browserslist": [
+    "extends @nextcloud/browserslist-config"
+  ]
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,128 +1,125 @@
 <template>
-  <NcContent app-name="grocerylist">
-    <NcAppNavigation>
-      <NcAppNavigationNew v-if="!loading"
-                          :text="t('grocerylist', 'New list')"
-                          :disabled="false"
-                          button-id="new-grocerylist-button"
-                          button-class="icon-add"
-                          @click="newGroceryList"/>
-      <ul>
-        <NavigationGroceryListItem v-for="groceryList in groceryLists"
-                                   :key="groceryList.id"
-                                   :title="groceryList.title ? groceryList.title : t('grocerylist', 'New list')"
-                                   :groceryList="groceryList"
-                                   :currentGroceryListId="currentGroceryListId" />
-      </ul>
-    </NcAppNavigation>
-    <NcAppContent>
-      <router-view/>
-    </NcAppContent>
-  </NcContent>
+	<NcContent app-name="grocerylist">
+		<NcAppNavigation>
+			<NcAppNavigationNew v-if="!loading"
+				:text="t('grocerylist', 'New list')"
+				:disabled="false"
+				button-id="new-grocerylist-button"
+				button-class="icon-add"
+				@click="newGroceryList" />
+			<ul>
+				<NavigationGroceryListItem v-for="groceryList in groceryLists"
+					:key="groceryList.id"
+					:title="groceryList.title ? groceryList.title : t('grocerylist', 'New list')"
+					:grocery-list="groceryList"
+					:current-grocery-list-id="currentGroceryListId" />
+			</ul>
+		</NcAppNavigation>
+		<NcAppContent>
+			<router-view />
+		</NcAppContent>
+	</NcContent>
 </template>
 
 <script>
+import { showError } from '@nextcloud/dialogs'
+import { generateUrl } from '@nextcloud/router'
 import {
-  NcAppNavigationNew,
-  NcAppNavigationItem,
-  NcSelect,
-  NcAppNavigation,
-  NcActionButton,
-  NcAppContent,
-  NcContent
+	NcAppNavigationNew,
+	NcAppNavigation,
+	NcAppContent,
+	NcContent,
 } from '@nextcloud/vue'
+
 import axios from '@nextcloud/axios'
-import NavigationGroceryListItem from "./components/NavigationGroceryListItem.vue"
+import NavigationGroceryListItem from './components/NavigationGroceryListItem.vue'
 
 export default {
-  name: 'App',
-  components: {
-    NcContent,
-    NcActionButton,
-    NcAppContent,
-    NcAppNavigation,
-    NcAppNavigationItem,
-    NcAppNavigationNew,
-    NcSelect,
-    NavigationGroceryListItem
-  },
-  data: function () {
-    return {
-      groceryLists: [],
-      items: [],
-      categories: [],
-      currentGroceryListId: -1,
-      updating: false,
-      loading: true,
-      modal: false,
-    }
-  },
-  computed: {
-    /**
-     * Return the currently selected groceryList object
-     * @returns {Object|null}
-     */
-    currentGroceryList () {
-      if (this.currentGroceryListId === null) {
-        return null
-      }
-      return this.groceryLists.find((groceryList) => groceryList.id === this.currentGroceryListId)
-    },
+	name: 'App',
+	components: {
+		NcContent,
+		NcAppContent,
+		NcAppNavigation,
+		NcAppNavigationNew,
+		NavigationGroceryListItem,
+	},
+	data() {
+		return {
+			groceryLists: [],
+			items: [],
+			categories: [],
+			currentGroceryListId: -1,
+			updating: false,
+			loading: true,
+			modal: false,
+		}
+	},
+	computed: {
+		/**
+		 * Return the currently selected groceryList object
+		 * @return {object | null}
+		 */
+		currentGroceryList() {
+			if (this.currentGroceryListId === null) {
+				return null
+			}
+			return this.groceryLists.find((groceryList) => groceryList.id === this.currentGroceryListId)
+		},
 
-    /**
-     * Returns true if a list is selected and its title is not empty
-     * @returns {Boolean}
-     */
-    savePossible () {
-      return this.currentGroceryList && this.currentGroceryList.title !== ''
-    },
-  },
-  created () {
-    this.onCreated()
-  },
-  /**
-   * Fetch list of groceryLists when the component is loaded
-   */
-  async mounted () {
-    try {
-      if (this.$route.name === "lists") {
-        console.warn("show single list" + this.$route.params)
-      }
+		/**
+		 * Returns true if a list is selected and its title is not empty
+		 * @return {boolean}
+		 */
+		savePossible() {
+			return this.currentGroceryList && this.currentGroceryList.title !== ''
+		},
+	},
+	created() {
+		this.onCreated()
+	},
+	/**
+	 * Fetch list of groceryLists when the component is loaded
+	 */
+	async mounted() {
+		try {
+			if (this.$route.name === 'lists') {
+				console.warn('show single list' + this.$route.params)
+			}
 
-      const response = await axios.get(OC.generateUrl('/apps/grocerylist/api/lists'))
-      this.groceryLists = response.data
-    } catch (e) {
-      console.error(e)
-      OCP.Toast.error(t('grocerylist', 'Could not fetch groceryLists'))
-    }
-    this.loading = false
-  },
-  methods: {
-    onCreated () {
-      if (this.$route.name === "lists") {
-        console.warn("show single list" + this.$route.params)
-      }
-    },
-    renameGroceryList (id, value) {
-      try {
-        axios.post(OC.generateUrl('/apps/grocerylist/api/list/' + id),
-            {
-              title: value
-            })
-      } catch (e) {
-        console.error(e)
-        OCP.Toast.error(t('grocerylist', 'Could not rename groceryList'))
-      }
-    },
-    newGroceryList () {
-      try {
-        const response = axios.post(OC.generateUrl('/apps/grocerylist/api/lists'), {title: ''})
-        // this.currentGroceryListId = response.data.id
-      } catch (e) {
-        console.error(e)
-        OCP.Toast.error(t('grocerylist', 'Could not create groceryList'))
-      }
-      /*
+			const response = await axios.get(generateUrl('/apps/grocerylist/api/lists'))
+			this.groceryLists = response.data
+		} catch (e) {
+			console.error(e)
+			showError(t('grocerylist', 'Could not fetch groceryLists'))
+		}
+		this.loading = false
+	},
+	methods: {
+		onCreated() {
+			if (this.$route.name === 'lists') {
+				console.warn('show single list' + this.$route.params)
+			}
+		},
+		renameGroceryList(id, value) {
+			try {
+				axios.post(generateUrl('/apps/grocerylist/api/list/' + id),
+					{
+						title: value,
+					})
+			} catch (e) {
+				console.error(e)
+				showError(t('grocerylist', 'Could not rename groceryList'))
+			}
+		},
+		async newGroceryList() {
+			try {
+				await axios.post(generateUrl('/apps/grocerylist/api/lists'), { title: '' })
+				// this.currentGroceryListId = response.data.id
+			} catch (e) {
+				console.error(e)
+				showError(t('grocerylist', 'Could not create groceryList'))
+			}
+			/*
     this.groceryLists.push({
       id: -1,
       title: '',
@@ -130,9 +127,9 @@ export default {
       showOnlyUnchecked: false,
     })
        */
-    }
-    ,
-  },
+		}
+		,
+	},
 }
 </script>
 <style scoped>

--- a/src/components/EditCategories.vue
+++ b/src/components/EditCategories.vue
@@ -1,16 +1,16 @@
 <template>
 	<div>
-		<h1>Categories for {{listId}}</h1>
+		<h1>Categories for {{ listId }}</h1>
 		<input ref="name"
-			   v-model="category"
-			   type="text"
-			   :disabled="updating"
-			   style="width: 30%">
+			v-model="category"
+			type="text"
+			:disabled="updating"
+			style="width: 30%">
 		<NcActionButton icon="icon-add"
-					  @click="onSaveCategory()"></NcActionButton>
-		<span v-for="category in categories">
+			@click="onSaveCategory()" />
+		<span v-for="subCategory in categories" :key="subCategory.id">
 			<ul>
-			<li @click="editCategory(category)">{{ category.name }}</li>
+				<li @click="editCategory(subCategory)">{{ subCategory.name }}</li>
 			</ul>
 
 		</span>
@@ -18,71 +18,73 @@
 </template>
 
 <script>
-import axios from "@nextcloud/axios";
-import {NcActionButton} from '@nextcloud/vue'
+import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+import { generateUrl } from '@nextcloud/router'
+import { NcActionButton } from '@nextcloud/vue'
 
 export default {
-	name: "EditCategories",
+	name: 'EditCategories',
 	components: {
-		NcActionButton
+		NcActionButton,
 	},
 	listId: '',
-	data: function () {
+	data() {
 		return {
-			listId: this.$attrs['listId'],
-			categories: this.$attrs['categories'],
+			listId: this.$attrs.listId,
+			categories: this.$attrs.categories,
 			updating: false,
 			category: '',
 			newCategoryId: -1,
 		}
 	},
 	methods: {
-		editCategory (category) {
-			this.newCategoryId = category.id;
-			this.category = category.name;
+		editCategory(category) {
+			this.newCategoryId = category.id
+			this.category = category.name
 		},
-		async onSaveCategory () {
+		async onSaveCategory() {
 			if (this.newCategoryId === -1) {
-				this.addCategory();
+				this.addCategory()
 			} else {
-				this.updateCategory();
+				this.updateCategory()
 			}
 		},
-		async addCategory () {
+		async addCategory() {
 			this.updating = true
 			try {
-				const response = await axios.post(OC.generateUrl(`/apps/grocerylist/api/category/${this.listId}/add`),
-						{
-							name: this.category
-						}
+				const response = await axios.post(generateUrl(`/apps/grocerylist/api/category/${this.listId}/add`),
+					{
+						name: this.category,
+					},
 				)
-				this.categories = response.data;
-				this.category = "";
+				this.categories = response.data
+				this.category = ''
 			} catch (e) {
 				console.error(e)
-				OCP.Toast.error(t('grocerylist', 'Could not add category to list ' . this.listId ))
+				showError(t('grocerylist', 'Could not add category to list '.this.listId))
 			}
 			this.updating = false
 		},
-		async updateCategory (listId) {
+		async updateCategory(listId) {
 			this.updating = true
 			try {
-				const response = await axios.post(OC.generateUrl(`/apps/grocerylist/api/category/update`),
-						{
-							id: this.newCategoryId,
-							newName: this.category,
-						}
+				const response = await axios.post(generateUrl('/apps/grocerylist/api/category/update'),
+					{
+						id: this.newCategoryId,
+						newName: this.category,
+					},
 				)
 
-				this.categories = response.data;
-				this.category = "";
+				this.categories = response.data
+				this.category = ''
 			} catch (e) {
 				console.error(e)
-				OCP.Toast.error(t('grocerylist', 'Could not update category'))
+				showError(t('grocerylist', 'Could not update category'))
 			}
 			this.updating = false
-		}
-	}
+		},
+	},
 }
 </script>
 <style lang="scss" scoped>

--- a/src/components/NavigationGroceryListItem.vue
+++ b/src/components/NavigationGroceryListItem.vue
@@ -44,6 +44,7 @@ export default {
 			required: true,
 		},
 	},
+	emits: ['delete'],
 	data() {
 		return {}
 	},
@@ -86,6 +87,7 @@ export default {
 				// 	this.currentGroceryListId = null
 				// }
 				showSuccess(t('grocerylist', 'GroceryList deleted'))
+				this.$emit('delete')
 			} catch (e) {
 				console.error(e)
 				showError(t('grocerylist', 'Could not delete groceryList'))

--- a/src/components/NavigationGroceryListItem.vue
+++ b/src/components/NavigationGroceryListItem.vue
@@ -1,21 +1,18 @@
 <template>
-	<NcAppNavigationItem
-		:name="title"
+	<NcAppNavigationItem :name="title"
 		:icon="icon"
 		:editable="true"
-		:editLabel="rename"
+		:edit-label="rename"
 		:to="{ name: 'list', params: { id: groceryList.id.toString() } }"
 		:class="{active: currentGroceryListId === groceryList.id}"
 		@click="openGroceryList(groceryList)"
 		@update:name="onRename">
 		<template #actions>
-			<NcActionButton
-				icon="icon-rename"
+			<NcActionButton icon="icon-rename"
 				@click="openSettings(groceryList)">
 				{{ t('grocerylist', 'Settings') }}
 			</NcActionButton>
-			<NcActionButton
-				icon="icon-delete"
+			<NcActionButton icon="icon-delete"
 				@click="deleteGroceryList(groceryList)">
 				{{ t('grocerylist', 'Delete list') }}
 			</NcActionButton>
@@ -23,18 +20,18 @@
 	</NcAppNavigationItem>
 </template>
 <script>
+import { showError, showInfo, showSuccess } from '@nextcloud/dialogs'
 import {
 	NcActionButton,
-	NcActionSeparator,
-	NcAppNavigationItem
+	NcAppNavigationItem,
 } from '@nextcloud/vue'
-import axios from "@nextcloud/axios";
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
 
 export default {
 	name: 'NavigationGroceryListItem',
 	components: {
 		NcActionButton,
-		NcActionSeparator,
 		NcAppNavigationItem,
 	},
 	props: {
@@ -45,72 +42,71 @@ export default {
 		currentGroceryListId: {
 			type: Number,
 			required: true,
-		}
+		},
 	},
-	data () {
+	data() {
 		return {}
 	},
 	computed: {
-		icon () {
+		icon() {
 			return 'icon-toggle-filelist'
 		},
-		rename () {
-			return "Rename " + this.groceryList.title
+		rename() {
+			return 'Rename ' + this.groceryList.title
 		},
-		title () {
+		title() {
 			return this.groceryList.title
-		}
+		},
 	},
 	methods: {
-		async onRename (newTitle) {
-      OCP.Toast.info("rename to " + newTitle)
+		async onRename(newTitle) {
+			showInfo('rename to ' + newTitle)
 			console.error('rename to ' + newTitle)
 			this.updating = true
 			this.groceryList.title = newTitle
 
 			try {
 				if (this.groceryList.id === -1) {
-					const response = await axios.post(OC.generateUrl('/apps/grocerylist/api/lists'), this.groceryList)
+					const response = await axios.post(generateUrl('/apps/grocerylist/api/lists'), this.groceryList)
 					this.currentGroceryListId = response.data.id
 				} else {
-					await axios.post(OC.generateUrl(`/apps/grocerylist/api/lists/${this.groceryList.id}`), this.groceryList)
+					await axios.post(generateUrl(`/apps/grocerylist/api/lists/${this.groceryList.id}`), this.groceryList)
 				}
 			} catch (e) {
 				console.error(e)
-				OCP.Toast.error(t('grocerylist', 'Could not create groceryList'))
+				showError(t('grocerylist', 'Could not create groceryList'))
 			}
 			this.updating = false
 		},
-		async deleteGroceryList (groceryList) {
+		async deleteGroceryList(groceryList) {
 			try {
-				await axios.delete(OC.generateUrl(`/apps/grocerylist/api/lists/${this.groceryList.id}`))
+				await axios.delete(generateUrl(`/apps/grocerylist/api/lists/${this.groceryList.id}`))
 				// this.groceryLists.splice(this.groceryLists.indexOf(groceryList), 1)
 				// if (this.currentGroceryListId === groceryList.id) {
 				// 	this.currentGroceryListId = null
 				// }
-				OCP.Toast.success(t('grocerylist', 'GroceryList deleted'))
+				showSuccess(t('grocerylist', 'GroceryList deleted'))
 			} catch (e) {
 				console.error(e)
-				OCP.Toast.error(t('grocerylist', 'Could not delete groceryList'))
+				showError(t('grocerylist', 'Could not delete groceryList'))
 			}
 		},
-		openSettings (groceryList) {
+		openSettings(groceryList) {
 			this.$router.push({
-				name: "settings",
+				name: 'settings',
 				params: {
-					listId: groceryList.id
-				}
+					listId: groceryList.id,
+				},
 			})
 		},
-		openGroceryList (groceryList) {
+		openGroceryList(groceryList) {
 			this.$router.push({
-				name: "list",
+				name: 'list',
 				params: {
-					listId: groceryList.id
-				}
+					listId: groceryList.id,
+				},
 			})
-		}
-	}
+		},
+	},
 }
 </script>
-

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -3,53 +3,51 @@
 		<div>
 			<h1>Categories for {{ listId }}</h1>
 			<input ref="name"
-						 v-model="category"
-						 type="text"
-						 :disabled="updating"
-						 v-on:keyup.enter="onSaveCategory()"
-						 style="width: 30%">
+				v-model="category"
+				type="text"
+				:disabled="updating"
+				style="width: 30%"
+				@keyup.enter="onSaveCategory()">
 			<NcActionButton icon="icon-add"
-										@click="onSaveCategory()"></NcActionButton>
-			<span v-for="category in categories">
-			<ul>
-			<li @click="editCategory(category)">{{ category.name }}</li>
-			</ul>
-		</span>
+				@click="onSaveCategory()" />
+			<span v-for="subCategory in categories" :key="subCategory.id">
+				<ul>
+					<li @click="editCategory(subCategory)">{{ subCategory.name }}</li>
+				</ul>
+			</span>
 		</div>
 		<div>
 			<h1>Share</h1>
-			<span v-for="sharee in sharees">
-			<ul>
-			<li>{{ sharee.userId }}</li>
-			</ul>
-		</span>
+			<span v-for="sharee in sharees" :key="sharee.userId">
+				<ul>
+					<li>{{ sharee.userId }}</li>
+				</ul>
+			</span>
 		</div>
 	</div>
 </template>
 
 <script>
-import axios from "@nextcloud/axios";
-import {NcActionButton} from "@nextcloud/vue";
+import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+import { generateUrl } from '@nextcloud/router'
+import { NcActionButton } from '@nextcloud/vue'
 
 export default {
-	name: "Settings",
+	name: 'Settings',
 	components: {
-		NcActionButton
+		NcActionButton,
 	},
 	listId: '',
-	data: function () {
+	data() {
 		return {
-			listId: this.$attrs['listId'],
+			listId: this.$attrs.listId,
 			categories: null,
 			updating: false,
 			category: '',
 			newCategoryId: -1,
 			sharees: null,
 		}
-	},
-	async mounted() {
-		await this.loadCategories(this.listId)
-		await this.loadSharees(this.listId)
 	},
 	watch: {
 		$route(to, from) {
@@ -58,75 +56,79 @@ export default {
 				this.loadCategories(this.listId)
 				this.loadSharees(this.listId)
 			}
-		}
+		},
+	},
+	async mounted() {
+		await this.loadCategories(this.listId)
+		await this.loadSharees(this.listId)
 	},
 	methods: {
 		editCategory(category) {
-			this.newCategoryId = category.id;
-			this.category = category.name;
+			this.newCategoryId = category.id
+			this.category = category.name
 		},
 		async onSaveCategory() {
 			if (this.newCategoryId === -1) {
-				await this.addCategory();
+				await this.addCategory()
 			} else {
-				await this.updateCategory();
+				await this.updateCategory()
 			}
 		},
 		async addCategory() {
 			this.updating = true
 			try {
-				const response = await axios.post(OC.generateUrl(`/apps/grocerylist/api/category/${this.listId}/add`),
-						{
-							name: this.category
-						}
+				const response = await axios.post(generateUrl(`/apps/grocerylist/api/category/${this.listId}/add`),
+					{
+						name: this.category,
+					},
 				)
-				this.categories = response.data;
-				this.category = "";
+				this.categories = response.data
+				this.category = ''
 			} catch (e) {
 				console.error(e)
-				OCP.Toast.error(t('grocerylist', 'Could not add category to list '.this.listId))
+				showError(t('grocerylist', 'Could not add category to list '.this.listId))
 			}
 			this.updating = false
 		},
 		async updateCategory(listId) {
 			this.updating = true
 			try {
-				const response = await axios.post(OC.generateUrl(`/apps/grocerylist/api/category/update`),
-						{
-							id: this.newCategoryId,
-							newName: this.category,
-						}
+				const response = await axios.post(generateUrl('/apps/grocerylist/api/category/update'),
+					{
+						id: this.newCategoryId,
+						newName: this.category,
+					},
 				)
 
-				this.categories = response.data;
-				this.category = "";
+				this.categories = response.data
+				this.category = ''
 			} catch (e) {
 				console.error(e)
-				OCP.Toast.error(t('grocerylist', 'Could not update category'))
+				showError(t('grocerylist', 'Could not update category'))
 			}
 			this.updating = false
 		},
 		async loadCategories(id) {
 			try {
-				const response = await axios.get(OC.generateUrl('/apps/grocerylist/api/all_categories/' + id))
+				const response = await axios.get(generateUrl('/apps/grocerylist/api/all_categories/' + id))
 				this.categories = response.data
 			} catch (e) {
 				console.error(e)
-				OCP.Toast.error(t('grocerylist', ('Could not fetch categories for groceryList ' + id)))
+				showError(t('grocerylist', ('Could not fetch categories for groceryList ' + id)))
 			}
 			this.loading = false
 		},
 		async loadSharees(id) {
 			try {
-				const response = await axios.get(OC.generateUrl('/apps/grocerylist/api/sharees/' + id))
+				const response = await axios.get(generateUrl('/apps/grocerylist/api/sharees/' + id))
 				this.sharees = response.data
 			} catch (e) {
 				console.error(e)
-				OCP.Toast.error(t('grocerylist', ('Could not fetch sharees for groceryList ' + id)))
+				showError(t('grocerylist', ('Could not fetch sharees for groceryList ' + id)))
 			}
 			this.loading = false
 		},
-	}
+	},
 }
 </script>
 <style lang="scss">

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@
  *
  * @author John Molakvoæ <skjnldsv@protonmail.com>
  *
- * @license GNU AGPL version 3 or any later version
+ * @license AGPL-3.0-or-later
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -29,7 +29,7 @@ Vue.prototype.OC = OC
 Vue.prototype.OCA = OCA
 
 export default new Vue({
-    el: '#content',
-    router,
-    render: h => h(App),
+	el: '#content',
+	router,
+	render: h => h(App),
 })

--- a/src/router.js
+++ b/src/router.js
@@ -1,9 +1,9 @@
 import Vue from 'vue'
 import Router from 'vue-router'
-import {generateUrl} from '@nextcloud/router'
+import { generateUrl } from '@nextcloud/router'
 
-import GroceryList from "./components/GroceryList.vue";
-import Settings from "./components/Settings.vue";
+import GroceryList from './components/GroceryList.vue'
+import Settings from './components/Settings.vue'
 
 Vue.use(Router)
 


### PR DESCRIPTION
1. Fix linting issues (run `npm run lint:fix`) for Nextcloud code style
2. Fix some deprecation issues, like the `OCP.Toast` or `OC.generateUrl`
3. Move runtime dependencies to `dependencies` and development dependencies to `devDependencies`.
4. Make the navigation reactive (meaning pressing "new list" now adds the list visually without the need to reload the page)
5. Also make removing a list reactive (removing also updates the visual list without reloading), for this simply emit a `delete` event.